### PR TITLE
Makes the PlatformIO Extension work on Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PlatformIO IDE for VSCode
+# PlatformIO IDE for Cursor
 
 [PlatformIO](https://platformio.org): Your Gateway to Embedded Software Development Excellence.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "platformio-ide",
-  "version": "3.3.4",
-  "publisher": "platformio",
+  "version": "3.3.5",
+  "publisher": "DavidGomes",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "vscode": "^1.65.0"
   },
   "license": "Apache-2.0",
-  "displayName": "PlatformIO IDE",
-  "description": "Your Gateway to Embedded Software Development Excellence: CMSIS, ESP-IDF, FreeRTOS, libOpenCM3, mbed OS, SPL, STM32Cube, Zephyr RTOS, Arduino, ARM, AVR, Espressif (ESP8266/ESP32), FPGA, MCS-51 (8051), MSP430, Nordic (nRF51/nRF52), PIC32, RISC-V, Raspberry Pi (RP2040), STMicroelectronics (STM8/STM32), Teensy",
+  "displayName": "PlatformIO IDE for Cursor",
+  "description": "Your Gateway to Embedded Software Development Excellence: CMSIS, ESP-IDF, FreeRTOS, libOpenCM3, mbed OS, SPL, STM32Cube, Zephyr RTOS, Arduino, ARM, AVR, Espressif (ESP8266/ESP32), FPGA, MCS-51 (8051), MSP430, Nordic (nRF51/nRF52), PIC32, RISC-V, Raspberry Pi (RP2040), STMicroelectronics (STM8/STM32), Teensy. This extension has been adapted for Cursor.",
   "categories": [
     "Programming Languages",
     "Linters",
@@ -697,7 +697,8 @@
       }
     ],
     "configurationDefaults": {
-      "C_Cpp.debugShortcut": false
+      "C_Cpp.debugShortcut": false,
+      "C_Cpp.intelliSenseEngine": "Disabled"
     },
     "configuration": {
       "type": "object",
@@ -905,6 +906,6 @@
     "webpack-cli": "~6.0.1"
   },
   "extensionDependencies": [
-    "ms-vscode.cpptools"
+    "llvm-vs-code-extensions.vscode-clangd"
   ]
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,7 +12,6 @@ export const IS_LINUX = !IS_WINDOWS && !IS_OSX;
 export const PIO_CORE_VERSION_SPEC = '>=6.1.6';
 export const STATUS_BAR_PRIORITY_START = 10;
 export const CONFLICTED_EXTENSION_IDS = [
-  'llvm-vs-code-extensions.vscode-clangd',
   'vsciot-vscode.vscode-arduino',
   'vscode-openapi',
 ];

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -259,6 +259,20 @@ export default class ProjectManager {
       extension.pioTerm.sendText(`cd "${projectDir}"`);
       extension.pioTerm.sendText('pio init --ide vscode');
       extension.pioTerm.sendText('pio run -t compiledb');
+
+      // Watch for the creation of `compile_commands.json`, and
+      // restart clangd when it appears.
+      const watcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(projectDir, 'compile_commands.json')
+      );
+
+      const disposable = watcher.onDidCreate(() => {
+        vscode.commands.executeCommand('clangd.restart').catch(() => {
+          // Silently ignore if clangd extension is not installed
+        });
+        disposable.dispose();
+        watcher.dispose();
+      });
     }
   }
 

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -107,22 +107,9 @@ export default class ProjectManager {
       vscode.workspace.onDidChangeWorkspaceFolders(() =>
         this.switchToProject(this.findActiveProjectDir()),
       ),
-      vscode.commands.registerCommand('platformio-ide.rebuildProjectIndex', async () => {
-        // Get the current project directory
-        const projectDir = this.findActiveProjectDir();
-        if (!projectDir) {
-          vscode.window.showErrorMessage('No PlatformIO project is currently open');
-          return;
-        }
-
-        // Run commands in the PIO terminal
-        extension.pioTerm.sendText(`cd "${projectDir}"`);
-        extension.pioTerm.sendText('pio init --ide vscode');
-        extension.pioTerm.sendText('pio run -t compiledb');
-        
-        // Also rebuild the index
-        return this._pool.getActiveObserver().rebuildIndex({ force: true });
-      }),
+      vscode.commands.registerCommand('platformio-ide.rebuildProjectIndex', () =>
+        this._pool.getActiveObserver().rebuildIndex({ force: true }),
+      ),
       vscode.commands.registerCommand('platformio-ide.refreshProjectTasks', () =>
         this._taskManager.refresh({ force: true }),
       ),
@@ -261,25 +248,19 @@ export default class ProjectManager {
     this.showSelectedEnv();
     this.saveActiveProjectState();
 
-    // Check if compile_commands.json exists, if not, generate it
+    // Generate a `compile_commands.json` in the project if it doesn't exist. This is
+    // so that the IntelliSense service using the clangd extension can work.
     const compileCommandsPath = path.join(projectDir, 'compile_commands.json');
     if (!fs.existsSync(compileCommandsPath)) {
-      // Check if we've already prompted for this project in this session
       const stateKey = `compileCommandsGenerated_${projectDir}`;
-      if (!extension.context.workspaceState.get(stateKey)) {
-        // Mark that we're generating for this project
-        extension.context.workspaceState.update(stateKey, true);
 
-        // Show a notification that we're generating compile_commands.json
-        vscode.window.showInformationMessage(
-          'Generating compile_commands.json for IntelliSense...'
-        );
+      vscode.window.showInformationMessage(
+        'Generating compile_commands.json for C/C++ IntelliSense...'
+      );
 
-        // Run the commands to generate compile_commands.json
-        extension.pioTerm.sendText(`cd "${projectDir}"`);
-        extension.pioTerm.sendText('pio init --ide vscode');
-        extension.pioTerm.sendText('pio run -t compiledb');
-      }
+      extension.pioTerm.sendText(`cd "${projectDir}"`);
+      extension.pioTerm.sendText('pio init --ide vscode');
+      extension.pioTerm.sendText('pio run -t compiledb');
     }
   }
 

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -17,6 +17,7 @@ import { STATUS_BAR_PRIORITY_START } from '../constants';
 import { extension } from '../main';
 import path from 'path';
 import vscode from 'vscode';
+import fs from 'fs';
 
 export default class ProjectManager {
   CONFIG_CHANGED_DELAY = 3; // seconds
@@ -106,9 +107,22 @@ export default class ProjectManager {
       vscode.workspace.onDidChangeWorkspaceFolders(() =>
         this.switchToProject(this.findActiveProjectDir()),
       ),
-      vscode.commands.registerCommand('platformio-ide.rebuildProjectIndex', () =>
-        this._pool.getActiveObserver().rebuildIndex({ force: true }),
-      ),
+      vscode.commands.registerCommand('platformio-ide.rebuildProjectIndex', async () => {
+        // Get the current project directory
+        const projectDir = this.findActiveProjectDir();
+        if (!projectDir) {
+          vscode.window.showErrorMessage('No PlatformIO project is currently open');
+          return;
+        }
+
+        // Run commands in the PIO terminal
+        extension.pioTerm.sendText(`cd "${projectDir}"`);
+        extension.pioTerm.sendText('pio init --ide vscode');
+        extension.pioTerm.sendText('pio run -t compiledb');
+        
+        // Also rebuild the index
+        return this._pool.getActiveObserver().rebuildIndex({ force: true });
+      }),
       vscode.commands.registerCommand('platformio-ide.refreshProjectTasks', () =>
         this._taskManager.refresh({ force: true }),
       ),
@@ -246,6 +260,27 @@ export default class ProjectManager {
 
     this.showSelectedEnv();
     this.saveActiveProjectState();
+
+    // Check if compile_commands.json exists, if not, generate it
+    const compileCommandsPath = path.join(projectDir, 'compile_commands.json');
+    if (!fs.existsSync(compileCommandsPath)) {
+      // Check if we've already prompted for this project in this session
+      const stateKey = `compileCommandsGenerated_${projectDir}`;
+      if (!extension.context.workspaceState.get(stateKey)) {
+        // Mark that we're generating for this project
+        extension.context.workspaceState.update(stateKey, true);
+
+        // Show a notification that we're generating compile_commands.json
+        vscode.window.showInformationMessage(
+          'Generating compile_commands.json for IntelliSense...'
+        );
+
+        // Run the commands to generate compile_commands.json
+        extension.pioTerm.sendText(`cd "${projectDir}"`);
+        extension.pioTerm.sendText('pio init --ide vscode');
+        extension.pioTerm.sendText('pio run -t compiledb');
+      }
+    }
   }
 
   registerEnvSwitcher() {

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -252,8 +252,6 @@ export default class ProjectManager {
     // so that the IntelliSense service using the clangd extension can work.
     const compileCommandsPath = path.join(projectDir, 'compile_commands.json');
     if (!fs.existsSync(compileCommandsPath)) {
-      const stateKey = `compileCommandsGenerated_${projectDir}`;
-
       vscode.window.showInformationMessage(
         'Generating compile_commands.json for C/C++ IntelliSense...'
       );

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ export async function notifyError(title, err) {
 }
 
 export function getIDEManifest() {
-  return vscode.extensions.getExtension('platformio.platformio-ide').packageJSON;
+  return vscode.extensions.getExtension('DavidGomes.platformio-ide').packageJSON;
 }
 
 export function getIDEVersion() {


### PR DESCRIPTION
The following changes make this extension work in Cursor (and possibly VSCodium and other VS Code distributions as well).

* Add a dependency on the `llvm-vs-code-extensions.vscode-clangd` extension
* Adds auto-generation of a `compile_commands.json` on every project change in PlatformIO
* Adds auto-restart of clangd's Language Server every time the `compile_commands.json` file is generated